### PR TITLE
Handle IPython magics in notebook test exports

### DIFF
--- a/ipynb_test.py
+++ b/ipynb_test.py
@@ -17,29 +17,29 @@ from nbconvert.exporters import PythonExporter
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _prepare_nbconvert_template() -> None:
+def _prepare_nbconvert_template() -> Path:
     temp_jupyter_dir = Path("/tmp/jupyter_templates")
     template_dir = temp_jupyter_dir / "nbconvert" / "templates" / "python"
     template_dir.mkdir(parents=True, exist_ok=True)
     template_file = template_dir / "index.py.j2"
-    if not template_file.exists():
-        template_file.write_text(
-            """# coding: utf-8
+    template = """# coding: utf-8
 {%- for cell in nb.cells -%}
 {%- if cell.cell_type == 'code' -%}
-{% for line in cell.source.splitlines() %}
-{{ line }}
-{% endfor %}
+{{ cell.source | ipython2python }}
 {% if not loop.last %}
 
 {% endif %}
 {%- endif -%}
 {%- endfor -%}
-""",
-            encoding="utf-8",
-        )
+"""
+    if (
+        not template_file.exists()
+        or template_file.read_text(encoding="utf-8") != template
+    ):
+        template_file.write_text(template, encoding="utf-8")
     os.environ.setdefault("JUPYTER_DATA_DIR", str(temp_jupyter_dir))
     os.environ.setdefault("JUPYTER_CONFIG_DIR", "/tmp")
+    return template_file
 
 
 def _startup_prelude() -> str:
@@ -80,9 +80,9 @@ def _notebook_source(notebook_path: Path) -> str:
 
         warnings.simplefilter("error", DrakeDeprecationWarning)
 
-    _prepare_nbconvert_template()
+    template_file = _prepare_nbconvert_template()
     notebook = nbformat.read(notebook_path, as_version=4)
-    exporter = PythonExporter()
+    exporter = PythonExporter(template_file=str(template_file))
     source, _ = exporter.from_notebook_node(notebook)
     return _startup_prelude() + source
 

--- a/test_ipynb_export.py
+++ b/test_ipynb_export.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import nbformat
+
+from htmlbook import ipynb_test
+
+
+def test_export_conditional_magic_and_refresh_cached_template(tmp_path, monkeypatch):
+    template_file = tmp_path / "nbconvert/templates/python/index.py.j2"
+    template_file.parent.mkdir(parents=True)
+    template_file.write_text("stale template", encoding="utf-8")
+    monkeypatch.setattr(
+        ipynb_test,
+        "Path",
+        lambda value: tmp_path if value == "/tmp/jupyter_templates" else Path(value),
+    )
+    monkeypatch.setattr(ipynb_test, "_startup_prelude", lambda: "")
+    # Explicit template selection must work even with a different Jupyter home.
+    monkeypatch.setenv("JUPYTER_DATA_DIR", str(tmp_path / "other-jupyter-home"))
+    notebook = nbformat.v4.new_notebook(
+        cells=[
+            nbformat.v4.new_code_cell(
+                'import sys\nif "google.colab" in sys.modules:\n'
+                "    %pip install -q manipulation\n"
+            ),
+            nbformat.v4.new_markdown_cell("This should not become Python."),
+            nbformat.v4.new_code_cell("result = 42"),
+        ]
+    )
+    notebook_path = tmp_path / "example.ipynb"
+    nbformat.write(notebook, notebook_path)
+    source = ipynb_test._notebook_source(notebook_path)
+    assert "ipython2python" in template_file.read_text(encoding="utf-8")
+    code = compile(source, str(notebook_path), "exec")
+
+    shell = Mock()
+    monkeypatch.delitem(sys.modules, "google.colab", raising=False)
+    namespace = {"get_ipython": lambda: shell}
+    exec(code, namespace)
+    shell.run_line_magic.assert_not_called()
+    assert namespace["result"] == 42
+
+    monkeypatch.setitem(sys.modules, "google.colab", Mock())
+    exec(code, namespace)
+    shell.run_line_magic.assert_called_once_with("pip", "install -q manipulation")


### PR DESCRIPTION
Notebook tests currently copy IPython syntax verbatim into Python scripts, so a conditional `%pip install` cell raises SyntaxError on environments using the custom template.

Convert each complete code cell with nbconvert's ipython2python filter. Refresh outdated cached templates and select the generated template explicitly so export behavior does not depend on Jupyter environment settings.

Validation: regression test covers stale-template replacement, multiple cells, a conflicting Jupyter data directory, and conditional pip execution in local/Colab environments without installing packages. All 95 manipulation teaching notebooks compile through the updated exporter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RussTedrake/htmlbook/21)
<!-- Reviewable:end -->
